### PR TITLE
Fix a QEMU -soundhw regression and enable SDL audio

### DIFF
--- a/runner
+++ b/runner
@@ -3,7 +3,7 @@
 # set pulse when using old -soundhw option
 if echo "$@" |grep -q soundhw; then
     export QEMU_AUDIO_DRV="pa"
-    export QEMU_PA_SERVER=$PULSE_SERVER
+    export QEMU_PA_SERVER="unix:$XDG_RUNTIME_DIR/pulse/native"
 fi
 
 exec "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -116,7 +116,7 @@ parts:
     configflags:
       - --prefix=/usr
       - --target-list=x86_64-softmmu,aarch64-softmmu,arm-softmmu
-      - --audio-drv-list=pa
+      - --audio-drv-list=pa,sdl
       - --enable-jemalloc
       - --enable-libusb
       - --enable-usb-redir


### PR DESCRIPTION
This pull request ensures that the old `-soundhw` option for QEMU has a reliable Pulse Audio unix domain socket defined. Correcting a regression I created, sorry 🙇 It also enables the SDL audio backend in QEMU.