### PR TITLE
Upgrade to v6.0.0 and build for arm64

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -30,6 +30,8 @@ confinement: strict
 architectures:
   - build-on: amd64
     run-on: amd64
+  - build-on: arm64
+    run-on: arm64
 
 layout:
   /usr/sbin/smbd:
@@ -110,7 +112,7 @@ parts:
   qemu:
     after: [ virgl ]
     source: git://git.qemu.org/qemu.git
-    source-tag: v4.2.0
+    source-tag: v6.0.0
     source-depth: 1
     plugin: autotools
     configflags:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -172,6 +172,7 @@ parts:
       - libnfs-dev
       - libiscsi-dev
       - libpulse-dev
+      - ninja-build
     stage-packages:
       - libaio1
       - libbluetooth3


### PR DESCRIPTION
This is a simple PR to lift QEMU up to v6.0.0 and allow building on arm64.