### PR TITLE
Add UEFI support

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -38,6 +38,8 @@ layout:
     bind: $SNAP/usr/share/seabios
   /usr/share/qemu:
     bind: $SNAP/usr/share/qemu
+  /usr/share/OVMF:
+    bind: $SNAP/usr/share/OVMF
 
 apps:
   qemu-virgil:
@@ -271,6 +273,7 @@ parts:
       - libxentoollog1
       - libxss1
       - multipath-tools
+      - ovmf
       - seabios
     prime:
       # Fix execstack warnings


### PR DESCRIPTION
Today, UEFI support is a must for nearly any OS, but the current Qemu snap lacks the firmware.

This patch fixes it.