### PR TITLE
Fix mouse offset in GTK frontend

### DIFF
--- a/patches/fix-mouse.diff
+++ b/patches/fix-mouse.diff
@@ -1,0 +1,26 @@
+diff --git a/ui/gtk.c b/ui/gtk.c
+index 428f02f2df..0a7aac2099 100644
+--- a/ui/gtk.c
++++ b/ui/gtk.c
+@@ -838,7 +838,6 @@ static gboolean gd_motion_event(GtkWidget *widget, GdkEventMotion *motion,
+ {
+     VirtualConsole *vc = opaque;
+     GtkDisplayState *s = vc->s;
+-    GdkWindow *window;
+     int x, y;
+     int mx, my;
+     int fbh, fbw;
+@@ -851,10 +850,9 @@ static gboolean gd_motion_event(GtkWidget *widget, GdkEventMotion *motion,
+     fbw = surface_width(vc->gfx.ds) * vc->gfx.scale_x;
+     fbh = surface_height(vc->gfx.ds) * vc->gfx.scale_y;
+ 
+-    window = gtk_widget_get_window(vc->gfx.drawing_area);
+-    ww = gdk_window_get_width(window);
+-    wh = gdk_window_get_height(window);
+-    ws = gdk_window_get_scale_factor(window);
++    ww = gtk_widget_get_allocated_width(widget);
++    wh = gtk_widget_get_allocated_height(widget);
++    ws = gtk_widget_get_scale_factor(widget);
+ 
+     mx = my = 0;
+     if (ww > fbw) {

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -159,6 +159,9 @@ parts:
       - PKG_CONFIG_PATH: $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET/pkgconfig:/usr/lib/$CRAFT_ARCH_TRIPLET/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}
       - PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/snap/snapcraft/current/bin/scriptlet-bin:$PATH
       - LD_LIBRARY_PATH: $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET:/usr/lib/$CRAFT_ARCH_TRIPLET${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+    override-pull: |
+      craftctl default
+      git apply $CRAFT_PROJECT_DIR/patches/fix-mouse.diff
     override-build: |
       $CRAFT_PROJECT_DIR/snapbuildtools/remove_common.py core22 gtk-common-themes gnome-42-2204
       craftctl default


### PR DESCRIPTION
The GTK frontend has an offset in the mouse due to the way GTK manages the absolute coordinates in a window (which includes the shadow part of the window).

This bug has been fixed in Qemu 8.0.0, so this patch backports it.