### PR TITLE
Bump version to stable qemu 9.2.0

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -140,7 +140,7 @@ parts:
   qemu:
     after: [ virgl ]
     source: https://gitlab.com/qemu-project/qemu.git
-    source-tag: v9.0.2
+    source-tag: v9.2.0
     source-depth: 1
     plugin: autotools
     autotools-configure-parameters:


### PR DESCRIPTION
Compiling 9.0.2 fails while cloning the edk2 submodule as the dependent submodule subhook (https://github.com/Zeex/subhook) [1] git repo is gone.

Instead of doing manual clone and patching the submodule with a valid clone, it's just better to use instead a newer stable version of qemu, since we've one.

[1] https://github.com/tianocore/edk2/issues/6398